### PR TITLE
Allow lunid=0

### DIFF
--- a/Modules/hpe3par_vlun.py
+++ b/Modules/hpe3par_vlun.py
@@ -225,7 +225,7 @@ specified to create a vlun',
                 None,
                 autolun)
         else:
-            if lunid:
+            if lunid is not None:
                 if not client_obj.vlunExists(
                         volume_name, lunid, host_name, port_pos):
                     client_obj.createVLUN(


### PR DESCRIPTION
LunIDs in the GUI can be 0. Currently, if 0 is used in Ansible config for lunid it will fail due to the check assuming 0 = false. This corrects the behavior.