### PR TITLE
Resolve idempotent issue for add/remove iscsi/fc paths

### DIFF
--- a/Modules/hpe3par_host.py
+++ b/Modules/hpe3par_host.py
@@ -511,7 +511,6 @@ null",
 
 def add_fc_path_to_host(
         client_obj,
-        storage_system_ip,
         storage_system_username,
         storage_system_password,
         host_name,
@@ -602,7 +601,6 @@ null",
 
 def add_iscsi_path_to_host(
         client_obj,
-        storage_system_ip,
         storage_system_username,
         storage_system_password,
         host_name,
@@ -819,7 +817,7 @@ def main():
             host_name)
     elif module.params["state"] == "add_fc_path_to_host":
         return_status, changed, msg, issue_attr_dict = add_fc_path_to_host(
-            client_obj, storage_system_ip, storage_system_username, storage_system_password,
+            client_obj, storage_system_username, storage_system_password,
             host_name, host_fc_wwns)
     elif module.params["state"] == "remove_fc_path_from_host":
         return_status, changed, msg, issue_attr_dict = (
@@ -828,7 +826,7 @@ def main():
                                      host_fc_wwns, force_path_removal))
     elif module.params["state"] == "add_iscsi_path_to_host":
         return_status, changed, msg, issue_attr_dict = add_iscsi_path_to_host(
-            client_obj, storage_system_ip, storage_system_username, storage_system_password,
+            client_obj, storage_system_username, storage_system_password,
             host_name, host_iscsi_names)
     elif module.params["state"] == "remove_iscsi_path_from_host":
         return_status, changed, msg, issue_attr_dict = (

--- a/Modules/hpe3par_host.py
+++ b/Modules/hpe3par_host.py
@@ -753,78 +753,47 @@ null",
             False,
             "Host modification failed. host_iscsi_names is null",
             {})
-    iqn_new = []
-    iqn_same_host = []
-    iqn_other_host = []
-    debug_list = []
+
     try:
         client_obj.login(storage_system_username, storage_system_password)
 
         # check various possibilities
-        #host_iscsi_names = ['iqn.1993-08.org.debian:01:90729193d333','iqn.1993-08.org.debian:01:90729193d222','iqn.1993-08.org.debian:01:90729193d111','iqn.1993-08.org.debian:01:90729193d000']
-        #host_iscsi_names = ['iqn.1993-08.org.debian:01:90729193d333','iqn.1993-08.org.debian:01:90729193d222']
-        #host_iscsi_names = ['iqn.1993-08.org.debian:01:90729193d333']
+        iqn_new = []
+        iqn_same_host = []
+        iqn_other_host = []
 
-        #debug_list.append('before_entering_for')
         for iqn in host_iscsi_names:
-            str_line = "inside_for_iqn " + iqn
-            debug_list.append(str_line)
             iscsi_name = [iqn]
-            #debug_list.append('calling_queryHost')
             host_list = client_obj.queryHost(iqns=iscsi_name)
-            #debug_list.append('type_host_list')
-            #str_2 = str(type(host_list))
-            #debug_list.append(str_2)
-
-            #debug_list.append('before_entering_for')
             for host_obj in host_list:
                 host_name_3par = host_obj.name
-                str_line = "host_name_3par " + host_name_3par
-                debug_list.append(str_line)
-                str_line = "host_name " + host_name
-                debug_list.append(str_line)
                 if host_name == host_name_3par:
-                    debug_list.append('host_name is same')
                     iqn_same_host.append(iqn)
                 else:
-                    debug_list.append('host_name is different')
                     iqn_other_host.append(iqn)
 
             if host_list == []:
-                debug_list.append('host_list_is_empty')
                 iqn_new.append(iqn)
 
-        debug_list.append('for_loop_completed')
-
         if iqn_other_host:
-            debug_list.append('if iqn_other_host')
             str_iqn = ", ".join(iqn_other_host)
             client_obj.logout()
             return(False, False, "iSCSI name(s) %s assigned to other host" % str_iqn, {})
         elif iqn_same_host:
-            debug_list.append('elif iqn_same_host')
             mod_request = {
                 'pathOperation': HPE3ParClient.HOST_EDIT_REMOVE,
                 'iSCSINames': iqn_same_host,
                 'forcePathRemoval': force_path_removal}
-
-            debug_list.append('calling modifyHost')
             client_obj.modifyHost(host_name, mod_request)
-
-            debug_list.append('calling logout')
             client_obj.logout()
-
             str_iqn = ", ".join(iqn_same_host)
-            debug_list.append('returning True True')
             return(True, True, "Removed iSCSI path(s) %s from host successfully." % str_iqn, {})
         elif iqn_new:
-            debug_list.append('elif iqn_new')
             str_iqn = ", ".join(iqn_new)
             client_obj.logout()
             return(True, False, "iSCSI name(s) %s seem to be already removed" % str_iqn, {})
 
     except Exception as e:
-        debug_list.append('exception occurred')
         return (
             False,
             False,
@@ -832,15 +801,7 @@ null",
             e,
             {})
     finally:
-        debug_list.append('inside_finally')
         client_obj.logout()
-        str_orig = ", ".join(host_iscsi_names)
-        str_other = ", ".join(iqn_other_host)
-        str_same = ", ".join(iqn_same_host)
-        str_new = ", ".join(iqn_new)
-        str_debug = ", ".join(debug_list)
-        return(False, False, "code should not reach here; orig: %s, other: %s, same: %s, new: %s, debug: %s" %
-            (str_orig, str_other, str_same, str_new, str_debug), {})
 
 
 def main():

--- a/Modules/hpe3par_host.py
+++ b/Modules/hpe3par_host.py
@@ -511,6 +511,7 @@ null",
 
 def add_fc_path_to_host(
         client_obj,
+        storage_system_ip,
         storage_system_username,
         storage_system_password,
         host_name,
@@ -538,6 +539,20 @@ null",
             {})
     try:
         client_obj.login(storage_system_username, storage_system_password)
+
+        # check if wwn is already assigned
+        client_obj.setSSHOptions(storage_system_ip, storage_system_username, storage_system_password)
+
+        for fc_wwn in host_fc_wwns:
+            host_name_3par = client_obj.findHost(wwn=fc_wwn)
+
+            if host_name_3par:
+                if host_name == host_name_3par:
+                    return (True, False, "WWN %s is already assigned to host" % fc_wwn, {})
+                else:
+                    err_msg = 'WWN is already used by another host'
+                    return (False, False, "Add FC path to host failed | %s" % err_msg, {})
+
         mod_request = {
             'pathOperation': HPE3ParClient.HOST_EDIT_ADD,
             'FCWWNs': host_fc_wwns}
@@ -593,6 +608,7 @@ null",
 
 def add_iscsi_path_to_host(
         client_obj,
+        storage_system_ip,
         storage_system_username,
         storage_system_password,
         host_name,
@@ -620,6 +636,20 @@ null",
             {})
     try:
         client_obj.login(storage_system_username, storage_system_password)
+
+        # check if wwn is already assigned
+        client_obj.setSSHOptions(storage_system_ip, storage_system_username, storage_system_password)
+
+        for iscsi_name in host_iscsi_names:
+            host_name_3par = client_obj.findHost(iqn=iscsi_name)
+
+            if host_name_3par:
+                if host_name == host_name_3par:
+                    return (True, False, "iSCSI name %s is already assigned to host" % iscsi_name, {})
+                else:
+                    err_msg = 'iSCSI name is already used by another host'
+                    return (False, False, "Add ISCSI path to host failed | %s" % err_msg, {})
+
         mod_request = {
             'pathOperation': HPE3ParClient.HOST_EDIT_ADD,
             'iSCSINames': host_iscsi_names}
@@ -801,7 +831,7 @@ def main():
             host_name)
     elif module.params["state"] == "add_fc_path_to_host":
         return_status, changed, msg, issue_attr_dict = add_fc_path_to_host(
-            client_obj, storage_system_username, storage_system_password,
+            client_obj, storage_system_ip, storage_system_username, storage_system_password,
             host_name, host_fc_wwns)
     elif module.params["state"] == "remove_fc_path_from_host":
         return_status, changed, msg, issue_attr_dict = (
@@ -810,7 +840,7 @@ def main():
                                      host_fc_wwns, force_path_removal))
     elif module.params["state"] == "add_iscsi_path_to_host":
         return_status, changed, msg, issue_attr_dict = add_iscsi_path_to_host(
-            client_obj, storage_system_username, storage_system_password,
+            client_obj, storage_system_ip, storage_system_username, storage_system_password,
             host_name, host_iscsi_names)
     elif module.params["state"] == "remove_iscsi_path_from_host":
         return_status, changed, msg, issue_attr_dict = (

--- a/Modules/hpe3par_host.py
+++ b/Modules/hpe3par_host.py
@@ -637,7 +637,7 @@ null",
     try:
         client_obj.login(storage_system_username, storage_system_password)
 
-        # check if wwn is already assigned
+        # check if iscsi name is already assigned
         client_obj.setSSHOptions(storage_system_ip, storage_system_username, storage_system_password)
 
         for iscsi_name in host_iscsi_names:

--- a/Modules/hpe3par_host.py
+++ b/Modules/hpe3par_host.py
@@ -541,17 +541,11 @@ null",
         client_obj.login(storage_system_username, storage_system_password)
 
         # check if wwn is already assigned
-        client_obj.setSSHOptions(storage_system_ip, storage_system_username, storage_system_password)
-
-        for fc_wwn in host_fc_wwns:
-            host_name_3par = client_obj.findHost(wwn=fc_wwn)
-
-            if host_name_3par:
-                if host_name == host_name_3par:
-                    return (True, False, "WWN %s is already assigned to host" % fc_wwn, {})
-                else:
-                    err_msg = 'WWN is already used by another host'
-                    return (False, False, "Add FC path to host failed | %s" % err_msg, {})
+        host_list = client_obj.queryHost(wwns=host_fc_wwns)
+        for host_obj in host_list:
+            host_name_3par = host_obj.name
+            if host_name == host_name_3par:
+                return (True, False, "WWN is already assigned to this host", {})
 
         mod_request = {
             'pathOperation': HPE3ParClient.HOST_EDIT_ADD,
@@ -638,17 +632,11 @@ null",
         client_obj.login(storage_system_username, storage_system_password)
 
         # check if iscsi name is already assigned
-        client_obj.setSSHOptions(storage_system_ip, storage_system_username, storage_system_password)
-
-        for iscsi_name in host_iscsi_names:
-            host_name_3par = client_obj.findHost(iqn=iscsi_name)
-
-            if host_name_3par:
-                if host_name == host_name_3par:
-                    return (True, False, "iSCSI name %s is already assigned to host" % iscsi_name, {})
-                else:
-                    err_msg = 'iSCSI name is already used by another host'
-                    return (False, False, "Add ISCSI path to host failed | %s" % err_msg, {})
+        host_list = client_obj.queryHost(iqns=host_iscsi_names)
+        for host_obj in host_list:
+            host_name_3par = host_obj.name
+            if host_name == host_name_3par:
+                return (True, False, "iSCSI name is already assigned to this host", {})
 
         mod_request = {
             'pathOperation': HPE3ParClient.HOST_EDIT_ADD,

--- a/test/unit/test_hpe3par_host.py
+++ b/test/unit/test_hpe3par_host.py
@@ -20,7 +20,7 @@ import mock
 from Modules import hpe3par_host as host
 from ansible.module_utils.basic import AnsibleModule as ansible
 import unittest
-
+from hpe3par_sdk.models import Host
 
 class TestHpe3parHost(unittest.TestCase):
 
@@ -684,7 +684,7 @@ class TestHpe3parHost(unittest.TestCase):
         """
         hpe3par host - add_fc_path_to_host
         """
-        result = host.add_fc_path_to_host(mock_client, None, None, None, None, None)
+        result = host.add_fc_path_to_host(mock_client, None, None, None, None)
 
         self.assertEqual(result, (
             False,
@@ -698,7 +698,7 @@ class TestHpe3parHost(unittest.TestCase):
         hpe3par host - add_fc_path_to_host
         """
         result = host.add_fc_path_to_host(
-            mock_client, "192.168.0.1", "user", "pass", None, None)
+            mock_client, "user", "pass", None, None)
 
         self.assertEqual(result, (
             False,
@@ -712,7 +712,7 @@ class TestHpe3parHost(unittest.TestCase):
         hpe3par host - add_fc_path_to_host
         """
         result = host.add_fc_path_to_host(
-            mock_client, "192.168.0.1", "user", "pass", "host", None)
+            mock_client, "user", "pass", "host", None)
 
         self.assertEqual(result, (
             False,
@@ -727,10 +727,10 @@ class TestHpe3parHost(unittest.TestCase):
         hpe3par host - add_fc_path_to_host
         """
         mock_client.HPE3ParClient.setSSHOptions.return_value = True
-        mock_client.HPE3ParClient.findHost.return_value = None
+        mock_client.HPE3ParClient.queryHost.return_value = []
         mock_HPE3ParClient.HOST_EDIT_ADD = 1
         result = host.add_fc_path_to_host(
-            mock_client.HPE3ParClient, "192.168.0.1", "user", "pass", "host", "fc")
+            mock_client.HPE3ParClient, "user", "pass", "hostname", "fc_wwn")
 
         self.assertEqual(result, (
             True, True, "Added FC path to host successfully.", {}))
@@ -743,7 +743,7 @@ class TestHpe3parHost(unittest.TestCase):
         mock_client.login.side_effect = Exception("Failed to login!")
         mock_client.return_value = mock_client
         result = host.add_fc_path_to_host(
-            mock_client, "192.168.0.1", "user", "pass", "host", "iscsi")
+            mock_client, "user", "pass", "hostname", "fc_wwn")
 
         self.assertEqual(result, (
             False, False, "Add FC path to host failed | Failed to login!", {}))
@@ -755,26 +755,14 @@ class TestHpe3parHost(unittest.TestCase):
         hpe3par host - add_fc_path_to_host
         """
         mock_client.HPE3ParClient.setSSHOptions.return_value = True
-        mock_client.HPE3ParClient.findHost.return_value = "host"
+        object_hash = {'name': 'hostname'}
+        host_obj = Host(object_hash)
+        mock_client.HPE3ParClient.queryHost.return_value = [host_obj]
         result = host.add_fc_path_to_host(
-            mock_client.HPE3ParClient, "192.168.0.1", "user", "pass", "host", "fc")
+            mock_client.HPE3ParClient, "user", "pass", "hostname", "fc_wwn")
 
         self.assertEqual(result, (
-            True, False, "WWN f is already assigned to host", {}))
-
-    @mock.patch('Modules.hpe3par_host.client')
-    @mock.patch('Modules.hpe3par_host.HPE3ParClient')
-    def test_add_FC_fail(self, mock_HPE3ParClient, mock_client):
-        """
-        hpe3par host - add_fc_path_to_host
-        """
-        mock_client.HPE3ParClient.setSSHOptions.return_value = True
-        mock_client.HPE3ParClient.findHost.return_value = "other_host"
-        result = host.add_fc_path_to_host(
-            mock_client.HPE3ParClient, "192.168.0.1", "user", "pass", "host", "fc")
-
-        self.assertEqual(result, (
-            False, False, "Add FC path to host failed | WWN is already used by another host", {}))
+            True, False, "WWN is already assigned to this host", {}))
 
     # Remove FC
     @mock.patch('Modules.hpe3par_host.client')
@@ -852,7 +840,7 @@ class TestHpe3parHost(unittest.TestCase):
         hpe3par host - add_iscsi_path_to_host
         """
         result = host.add_iscsi_path_to_host(
-            mock_client, None, None, None, None, None)
+            mock_client, None, None, None, None)
 
         self.assertEqual(result, (
             False,
@@ -866,7 +854,7 @@ class TestHpe3parHost(unittest.TestCase):
         hpe3par host - add_iscsi_path_to_host
         """
         result = host.add_iscsi_path_to_host(
-            mock_client, "192.168.0.1", "user", "pass", None, None)
+            mock_client, "user", "pass", None, None)
 
         self.assertEqual(result, (
             False,
@@ -880,7 +868,7 @@ class TestHpe3parHost(unittest.TestCase):
         hpe3par host - add_iscsi_path_to_host
         """
         result = host.add_iscsi_path_to_host(
-            mock_client, "192.168.0.1", "user", "pass", "host", None)
+            mock_client, "user", "pass", "host", None)
 
         self.assertEqual(result, (
             False,
@@ -895,10 +883,10 @@ class TestHpe3parHost(unittest.TestCase):
         hpe3par host - add_iscsi_path_to_host
         """
         mock_client.HPE3ParClient.setSSHOptions.return_value = True
-        mock_client.HPE3ParClient.findHost.return_value = None
+        mock_client.HPE3ParClient.queryHost.return_value = []
         mock_HPE3ParClient.HOST_EDIT_ADD = 1
         result = host.add_iscsi_path_to_host(
-            mock_client.HPE3ParClient, "192.168.0.1", "user", "pass", "host", "iscsi")
+            mock_client.HPE3ParClient, "user", "pass", "hostname", "iscsi_iqn")
 
         self.assertEqual(result, (
             True, True, "Added ISCSI path to host successfully.", {}))
@@ -911,7 +899,7 @@ class TestHpe3parHost(unittest.TestCase):
         mock_client.login.side_effect = Exception("Failed to login!")
         mock_client.return_value = mock_client
         result = host.add_iscsi_path_to_host(
-            mock_client, "192.168.0.1", "user", "pass", "host", "iscsi")
+            mock_client, "user", "pass", "hostname", "iscsi_iqn")
 
         self.assertEqual(result, (
             False, False, "Add ISCSI path to host failed | Failed to login!", {}))
@@ -923,26 +911,14 @@ class TestHpe3parHost(unittest.TestCase):
         hpe3par host - add_iscsi_path_to_host
         """
         mock_client.HPE3ParClient.setSSHOptions.return_value = True
-        mock_client.HPE3ParClient.findHost.return_value = "host"
+        object_hash = {'name': 'hostname'}
+        host_obj = Host(object_hash)
+        mock_client.HPE3ParClient.queryHost.return_value = [host_obj]
         result = host.add_iscsi_path_to_host(
-            mock_client.HPE3ParClient, "192.168.0.1", "user", "pass", "host", "iscsi")
+            mock_client.HPE3ParClient, "user", "pass", "hostname", "iscsi_iqn")
 
         self.assertEqual(result, (
-            True, False, "iSCSI name i is already assigned to host", {}))
-
-    @mock.patch('Modules.hpe3par_host.client')
-    @mock.patch('Modules.hpe3par_host.HPE3ParClient')
-    def test_add_iscsi_fail(self, mock_HPE3ParClient, mock_client):
-        """
-        hpe3par host - add_iscsi_path_to_host
-        """
-        mock_client.HPE3ParClient.setSSHOptions.return_value = True
-        mock_client.HPE3ParClient.findHost.return_value = "other_host"
-        result = host.add_iscsi_path_to_host(
-            mock_client.HPE3ParClient, "192.168.0.1", "user", "pass", "host", "iscsi")
-
-        self.assertEqual(result, (
-            False, False, "Add ISCSI path to host failed | iSCSI name is already used by another host", {}))
+            True, False, "iSCSI name is already assigned to this host", {}))
 
     # Remove ISCSI
     @mock.patch('Modules.hpe3par_host.client')

--- a/test/unit/test_hpe3par_host.py
+++ b/test/unit/test_hpe3par_host.py
@@ -684,7 +684,7 @@ class TestHpe3parHost(unittest.TestCase):
         """
         hpe3par host - add_fc_path_to_host
         """
-        result = host.add_fc_path_to_host(mock_client, None, None, None, None)
+        result = host.add_fc_path_to_host(mock_client, None, None, None, None, None)
 
         self.assertEqual(result, (
             False,
@@ -698,7 +698,7 @@ class TestHpe3parHost(unittest.TestCase):
         hpe3par host - add_fc_path_to_host
         """
         result = host.add_fc_path_to_host(
-            mock_client, "user", "pass", None, None)
+            mock_client, "192.168.0.1", "user", "pass", None, None)
 
         self.assertEqual(result, (
             False,
@@ -712,7 +712,7 @@ class TestHpe3parHost(unittest.TestCase):
         hpe3par host - add_fc_path_to_host
         """
         result = host.add_fc_path_to_host(
-            mock_client, "user", "pass", "host", None)
+            mock_client, "192.168.0.1", "user", "pass", "host", None)
 
         self.assertEqual(result, (
             False,
@@ -726,9 +726,11 @@ class TestHpe3parHost(unittest.TestCase):
         """
         hpe3par host - add_fc_path_to_host
         """
+        mock_client.HPE3ParClient.setSSHOptions.return_value = True
+        mock_client.HPE3ParClient.findHost.return_value = None
         mock_HPE3ParClient.HOST_EDIT_ADD = 1
         result = host.add_fc_path_to_host(
-            mock_client.HPE3ParClient, "user", "pass", "host", "iscsi")
+            mock_client.HPE3ParClient, "192.168.0.1", "user", "pass", "host", "fc")
 
         self.assertEqual(result, (
             True, True, "Added FC path to host successfully.", {}))
@@ -741,10 +743,38 @@ class TestHpe3parHost(unittest.TestCase):
         mock_client.login.side_effect = Exception("Failed to login!")
         mock_client.return_value = mock_client
         result = host.add_fc_path_to_host(
-            mock_client, "user", "pass", "host", "iscsi")
+            mock_client, "192.168.0.1", "user", "pass", "host", "iscsi")
 
         self.assertEqual(result, (
             False, False, "Add FC path to host failed | Failed to login!", {}))
+
+    @mock.patch('Modules.hpe3par_host.client')
+    @mock.patch('Modules.hpe3par_host.HPE3ParClient')
+    def test_add_FC_already_present(self, mock_HPE3ParClient, mock_client):
+        """
+        hpe3par host - add_fc_path_to_host
+        """
+        mock_client.HPE3ParClient.setSSHOptions.return_value = True
+        mock_client.HPE3ParClient.findHost.return_value = "host"
+        result = host.add_fc_path_to_host(
+            mock_client.HPE3ParClient, "192.168.0.1", "user", "pass", "host", "fc")
+
+        self.assertEqual(result, (
+            True, False, "WWN f is already assigned to host", {}))
+
+    @mock.patch('Modules.hpe3par_host.client')
+    @mock.patch('Modules.hpe3par_host.HPE3ParClient')
+    def test_add_FC_fail(self, mock_HPE3ParClient, mock_client):
+        """
+        hpe3par host - add_fc_path_to_host
+        """
+        mock_client.HPE3ParClient.setSSHOptions.return_value = True
+        mock_client.HPE3ParClient.findHost.return_value = "other_host"
+        result = host.add_fc_path_to_host(
+            mock_client.HPE3ParClient, "192.168.0.1", "user", "pass", "host", "fc")
+
+        self.assertEqual(result, (
+            False, False, "Add FC path to host failed | WWN is already used by another host", {}))
 
     # Remove FC
     @mock.patch('Modules.hpe3par_host.client')
@@ -822,7 +852,7 @@ class TestHpe3parHost(unittest.TestCase):
         hpe3par host - add_iscsi_path_to_host
         """
         result = host.add_iscsi_path_to_host(
-            mock_client, None, None, None, None)
+            mock_client, None, None, None, None, None)
 
         self.assertEqual(result, (
             False,
@@ -836,7 +866,7 @@ class TestHpe3parHost(unittest.TestCase):
         hpe3par host - add_iscsi_path_to_host
         """
         result = host.add_iscsi_path_to_host(
-            mock_client, "user", "pass", None, None)
+            mock_client, "192.168.0.1", "user", "pass", None, None)
 
         self.assertEqual(result, (
             False,
@@ -850,7 +880,7 @@ class TestHpe3parHost(unittest.TestCase):
         hpe3par host - add_iscsi_path_to_host
         """
         result = host.add_iscsi_path_to_host(
-            mock_client, "user", "pass", "host", None)
+            mock_client, "192.168.0.1", "user", "pass", "host", None)
 
         self.assertEqual(result, (
             False,
@@ -864,9 +894,11 @@ class TestHpe3parHost(unittest.TestCase):
         """
         hpe3par host - add_iscsi_path_to_host
         """
+        mock_client.HPE3ParClient.setSSHOptions.return_value = True
+        mock_client.HPE3ParClient.findHost.return_value = None
         mock_HPE3ParClient.HOST_EDIT_ADD = 1
         result = host.add_iscsi_path_to_host(
-            mock_client.HPE3ParClient, "user", "pass", "host", "iscsi")
+            mock_client.HPE3ParClient, "192.168.0.1", "user", "pass", "host", "iscsi")
 
         self.assertEqual(result, (
             True, True, "Added ISCSI path to host successfully.", {}))
@@ -879,10 +911,38 @@ class TestHpe3parHost(unittest.TestCase):
         mock_client.login.side_effect = Exception("Failed to login!")
         mock_client.return_value = mock_client
         result = host.add_iscsi_path_to_host(
-            mock_client, "user", "pass", "host", "iscsi")
+            mock_client, "192.168.0.1", "user", "pass", "host", "iscsi")
 
         self.assertEqual(result, (
             False, False, "Add ISCSI path to host failed | Failed to login!", {}))
+
+    @mock.patch('Modules.hpe3par_host.client')
+    @mock.patch('Modules.hpe3par_host.HPE3ParClient')
+    def test_add_iscsi_already_present(self, mock_HPE3ParClient, mock_client):
+        """
+        hpe3par host - add_iscsi_path_to_host
+        """
+        mock_client.HPE3ParClient.setSSHOptions.return_value = True
+        mock_client.HPE3ParClient.findHost.return_value = "host"
+        result = host.add_iscsi_path_to_host(
+            mock_client.HPE3ParClient, "192.168.0.1", "user", "pass", "host", "iscsi")
+
+        self.assertEqual(result, (
+            True, False, "iSCSI name i is already assigned to host", {}))
+
+    @mock.patch('Modules.hpe3par_host.client')
+    @mock.patch('Modules.hpe3par_host.HPE3ParClient')
+    def test_add_iscsi_fail(self, mock_HPE3ParClient, mock_client):
+        """
+        hpe3par host - add_iscsi_path_to_host
+        """
+        mock_client.HPE3ParClient.setSSHOptions.return_value = True
+        mock_client.HPE3ParClient.findHost.return_value = "other_host"
+        result = host.add_iscsi_path_to_host(
+            mock_client.HPE3ParClient, "192.168.0.1", "user", "pass", "host", "iscsi")
+
+        self.assertEqual(result, (
+            False, False, "Add ISCSI path to host failed | iSCSI name is already used by another host", {}))
 
     # Remove ISCSI
     @mock.patch('Modules.hpe3par_host.client')

--- a/test/unit/test_hpe3par_host.py
+++ b/test/unit/test_hpe3par_host.py
@@ -882,7 +882,6 @@ class TestHpe3parHost(unittest.TestCase):
         """
         hpe3par host - add_iscsi_path_to_host
         """
-        mock_client.HPE3ParClient.setSSHOptions.return_value = True
         mock_client.HPE3ParClient.queryHost.return_value = []
         mock_HPE3ParClient.HOST_EDIT_ADD = 1
         result = host.add_iscsi_path_to_host(
@@ -906,19 +905,35 @@ class TestHpe3parHost(unittest.TestCase):
 
     @mock.patch('Modules.hpe3par_host.client')
     @mock.patch('Modules.hpe3par_host.HPE3ParClient')
-    def test_add_iscsi_already_present(self, mock_HPE3ParClient, mock_client):
+    def test_add_iscsi_assigned_same_host(self, mock_HPE3ParClient, mock_client):
         """
         hpe3par host - add_iscsi_path_to_host
         """
-        mock_client.HPE3ParClient.setSSHOptions.return_value = True
         object_hash = {'name': 'hostname'}
         host_obj = Host(object_hash)
         mock_client.HPE3ParClient.queryHost.return_value = [host_obj]
+        iqn_list = ['iqn.333', 'iqn.222']
         result = host.add_iscsi_path_to_host(
-            mock_client.HPE3ParClient, "user", "pass", "hostname", "iscsi_iqn")
+            mock_client.HPE3ParClient, "user", "pass", "hostname", iqn_list)
 
         self.assertEqual(result, (
-            True, False, "iSCSI name is already assigned to this host", {}))
+            True, False, "iSCSI name(s) iqn.333, iqn.222 already assigned to this host", {}))
+
+    @mock.patch('Modules.hpe3par_host.client')
+    @mock.patch('Modules.hpe3par_host.HPE3ParClient')
+    def test_add_iscsi_assigned_other_host(self, mock_HPE3ParClient, mock_client):
+        """
+        hpe3par host - add_iscsi_path_to_host
+        """
+        object_hash = {'name': 'other_hostname'}
+        host_obj = Host(object_hash)
+        mock_client.HPE3ParClient.queryHost.return_value = [host_obj]
+        iqn_list = ['iqn.111', 'iqn.000']
+        result = host.add_iscsi_path_to_host(
+            mock_client.HPE3ParClient, "user", "pass", "hostname", iqn_list)
+
+        self.assertEqual(result, (
+            False, False, "iSCSI name(s) iqn.111, iqn.000 already assigned to other host", {}))
 
     # Remove ISCSI
     @mock.patch('Modules.hpe3par_host.client')

--- a/test/unit/test_hpe3par_host.py
+++ b/test/unit/test_hpe3par_host.py
@@ -1057,6 +1057,36 @@ class TestHpe3parHost(unittest.TestCase):
         self.assertEqual(result, (
             False, False, "Remove ISCSI path from host failed | Failed to login!", {}))
 
+    @mock.patch('Modules.hpe3par_host.client')
+    @mock.patch('Modules.hpe3par_host.HPE3ParClient')
+    def test_remove_iscsi_already_removed(self, mock_HPE3ParClient, mock_client):
+        """
+        hpe3par host - remove_iscsi_path_from_host
+        """
+        mock_client.HPE3ParClient.queryHost.return_value = []
+        iqn_list = ['iqn.333', 'iqn.222']
+        result = host.remove_iscsi_path_from_host(
+            mock_client.HPE3ParClient, "user", "pass", "hostname", iqn_list, None)
+
+        self.assertEqual(result, (
+            True, False, "iSCSI name(s) iqn.333, iqn.222 seem to be already removed", {}))
+
+    @mock.patch('Modules.hpe3par_host.client')
+    @mock.patch('Modules.hpe3par_host.HPE3ParClient')
+    def test_remove_iscsi_assigned_other_host(self, mock_HPE3ParClient, mock_client):
+        """
+        hpe3par host - remove_iscsi_path_from_host
+        """
+        object_hash = {'name': 'other_hostname'}
+        host_obj = Host(object_hash)
+        mock_client.HPE3ParClient.queryHost.return_value = [host_obj]
+        iqn_list = ['iqn.111', 'iqn.000']
+        result = host.remove_iscsi_path_from_host(
+            mock_client.HPE3ParClient, "user", "pass", "hostname", iqn_list, None)
+
+        self.assertEqual(result, (
+            False, False, "iSCSI name(s) iqn.111, iqn.000 assigned to other host", {}))
+
 # main tests
 
     @mock.patch('Modules.hpe3par_host.client')

--- a/test/unit/test_hpe3par_host.py
+++ b/test/unit/test_hpe3par_host.py
@@ -726,14 +726,13 @@ class TestHpe3parHost(unittest.TestCase):
         """
         hpe3par host - add_fc_path_to_host
         """
-        mock_client.HPE3ParClient.setSSHOptions.return_value = True
         mock_client.HPE3ParClient.queryHost.return_value = []
         mock_HPE3ParClient.HOST_EDIT_ADD = 1
         result = host.add_fc_path_to_host(
-            mock_client.HPE3ParClient, "user", "pass", "hostname", "fc_wwn")
+            mock_client.HPE3ParClient, "user", "pass", "hostname", ['fc_wwn'])
 
         self.assertEqual(result, (
-            True, True, "Added FC path to host successfully.", {}))
+            True, True, "Added FC path(s) fc_wwn to host successfully.", {}))
 
     @mock.patch('Modules.hpe3par_host.client')
     def test_add_FC_exception(self, mock_client):
@@ -750,19 +749,35 @@ class TestHpe3parHost(unittest.TestCase):
 
     @mock.patch('Modules.hpe3par_host.client')
     @mock.patch('Modules.hpe3par_host.HPE3ParClient')
-    def test_add_FC_already_present(self, mock_HPE3ParClient, mock_client):
+    def test_add_FC_same_host(self, mock_HPE3ParClient, mock_client):
         """
         hpe3par host - add_fc_path_to_host
         """
-        mock_client.HPE3ParClient.setSSHOptions.return_value = True
         object_hash = {'name': 'hostname'}
         host_obj = Host(object_hash)
         mock_client.HPE3ParClient.queryHost.return_value = [host_obj]
+        wwn_list = ['wwn.333', 'wwn.222']
         result = host.add_fc_path_to_host(
-            mock_client.HPE3ParClient, "user", "pass", "hostname", "fc_wwn")
+            mock_client.HPE3ParClient, "user", "pass", "hostname", wwn_list)
 
         self.assertEqual(result, (
-            True, False, "WWN is already assigned to this host", {}))
+            True, False, "FC path(s) wwn.333, wwn.222 already assigned to this host", {}))
+
+    @mock.patch('Modules.hpe3par_host.client')
+    @mock.patch('Modules.hpe3par_host.HPE3ParClient')
+    def test_add_FC_assigned_other_host(self, mock_HPE3ParClient, mock_client):
+        """
+        hpe3par host - add_iscsi_path_to_host
+        """
+        object_hash = {'name': 'other_hostname'}
+        host_obj = Host(object_hash)
+        mock_client.HPE3ParClient.queryHost.return_value = [host_obj]
+        wwn_list = ['wwn.111', 'wwn.000']
+        result = host.add_fc_path_to_host(
+            mock_client.HPE3ParClient, "user", "pass", "hostname", wwn_list)
+
+        self.assertEqual(result, (
+            False, False, "FC path(s) wwn.111, wwn.000 already assigned to other host", {}))
 
     # Remove FC
     @mock.patch('Modules.hpe3par_host.client')
@@ -885,10 +900,10 @@ class TestHpe3parHost(unittest.TestCase):
         mock_client.HPE3ParClient.queryHost.return_value = []
         mock_HPE3ParClient.HOST_EDIT_ADD = 1
         result = host.add_iscsi_path_to_host(
-            mock_client.HPE3ParClient, "user", "pass", "hostname", "iscsi_iqn")
+            mock_client.HPE3ParClient, "user", "pass", "hostname", ['iscsi_iqn'])
 
         self.assertEqual(result, (
-            True, True, "Added ISCSI path to host successfully.", {}))
+            True, True, "Added iSCSI path(s) iscsi_iqn to host successfully.", {}))
 
     @mock.patch('Modules.hpe3par_host.client')
     def test_add_iscsi_exception(self, mock_client):


### PR DESCRIPTION
When using ansible playbook (multiple times) on same host & 3PAR, below message is reported as “ERROR”;
and execution of playbook is stopped:
host WWN/iSCSI name already used by another host
As per customer, a warning should be displayed and execution should proceed.
Customer comment: this action is Idempotent i.e they can be run multiple times on the same system and the results will always be identical, without producing unintended side effects.

Performed code changes to resolve this.
